### PR TITLE
update items for intializing a package section

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -66,20 +66,20 @@ code files provided to appropriate places, and creates skeleton help
 files and a Read-and-delete-me file describing further steps in
 packaging.
 
+When initializing a package, it is worth considering how it should be licensed. The CRAN Repository Policy links to a [database of licenses acceptable for CRAN](https://svn.r-project.org/R/trunk/share/licenses/license.db).
+
 WRE reference: [Package Structure](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Package-structure).
 
+ - `r pkg("available")` checks whether a package name is valid and available, i.e., not already in use on CRAN, Bioconductor or GitHub. Also checks for unintended meanings of the name. `r pkg("collidr")` checks for collisions between a package or function name and existing names of packages and/or functions on CRAN.
  - `r pkg("usethis", priority = "core")` has many utilities to setup the structure of the package, including a NEWS file and adding dependencies in the README.
  - `r pkg("pkgKitten")` provides an almost empty package skeleton and some utilities to create help pages.
- - `r bioc("biocthis")` prepares for Bioconductor repository.
-
-Some packages like `r pkg("fusen")` and `r github("jacobbien/litr-project")` prepare a project from an R markdown file. 
-`r pkg("noweb")` allows to use literate programming to create the package.
-There are others that help packaging several R files, `r pkg("rfold")`, or create a package from a dataset `r pkg("DataPackageR")`.
-Others, like `r pkg("cookiecutter")` can create a new package from a template stored elsewhere. 
-
-SEE ALSO:  
-<https://github.com/ropensci-archive/PackageDevelopment/blob/master/README-NOT.md#initializing-an-r-package>,
-<https://github.com/IndrajeetPatil/awesome-r-pkgtools?tab=readme-ov-file#package-templates->, <https://github.com/IndrajeetPatil/awesome-r-pkgtools?tab=readme-ov-file#naming-things->
+ - `Rcpp.package.skeleton()` from `r pkg("Rcpp")` extends `package.skeleton()` to add the components required to use `r pkg("Rcpp")` for interfacing C or C++ code in R packages. `r pkg("usethis")` provide similar functionality with the `use_c()` and `use_rcpp()` functions.
+ - `r bioc("biocthis")` automates setup for Bioconductor packages.
+ - `r github("r.pkg.template")` initializes a GitHub repository for an R package, with the standard files and directories, along with CI/CD configurations and pre-commit git hooks to identify and resolve common issues.
+ - `r pkg("fusen")` and `r github("jacobbien/litr-project")` create a package from a R markdown file. `r pkg("noweb")` creates a package via literate programming with noweb syntax (as used by Sweave).
+ - `r pkg("DataPackageR")` creates a package from a dataset. `r pkg("rcompendium")` creates the structure for a Research Compendium: an R package structure to support repreoducible research including raw data, analysis scripts, outputs and a make script.
+ - `r pkg("leprechaun")` adds templating code to a package skeleton for creating a Shiny app as a package, without adding to the dependencies. `r pkg("golem")` creates a package template for developing and deploying a Shiny app using the `r pkg("golem")` framework.
+ - `r pkg("pkgverse")` creates a meta package that bundles several related packages that can be installed and loaded together.
 
 ## Package development
 

--- a/proposal.md
+++ b/proposal.md
@@ -77,7 +77,7 @@ WRE reference: [Package Structure](https://cran.r-project.org/doc/manuals/r-rele
  - `r bioc("biocthis")` automates setup for Bioconductor packages.
  - `r github("insightsengineering/r.pkg.template")` initializes a GitHub repository for an R package, with the standard files and directories, along with CI/CD configurations and pre-commit git hooks to identify and resolve common issues.
  - `r pkg("fusen")` and `r github("jacobbien/litr-project")` create a package from a R markdown file. `r pkg("noweb")` creates a package via literate programming with noweb syntax (as used by Sweave).
- - `r pkg("DataPackageR")` creates a package from a dataset. `r pkg("rcompendium")` creates the structure for a Research Compendium: an R package structure to support repreoducible research including raw data, analysis scripts, outputs and a make script.
+ - `r pkg("DataPackageR")` creates a package from a dataset. `r pkg("rcompendium")` creates the structure for a Research Compendium: an R package structure to support reproducible research including raw data, analysis scripts, outputs and a make script.
  - `r pkg("leprechaun")` adds templating code to a package skeleton for creating a Shiny app as a package, without adding to the dependencies. `r pkg("golem")` creates a package template for developing and deploying a Shiny app using the `r pkg("golem")` framework.
  - `r pkg("pkgverse")` creates a meta package that bundles several related packages that can be installed and loaded together.
 

--- a/proposal.md
+++ b/proposal.md
@@ -75,7 +75,7 @@ WRE reference: [Package Structure](https://cran.r-project.org/doc/manuals/r-rele
  - `r pkg("pkgKitten")` provides an almost empty package skeleton and some utilities to create help pages.
  - `Rcpp.package.skeleton()` from `r pkg("Rcpp")` extends `package.skeleton()` to add the components required to use `r pkg("Rcpp")` for interfacing C or C++ code in R packages. `r pkg("usethis")` provide similar functionality with the `use_c()` and `use_rcpp()` functions.
  - `r bioc("biocthis")` automates setup for Bioconductor packages.
- - `r github("r.pkg.template")` initializes a GitHub repository for an R package, with the standard files and directories, along with CI/CD configurations and pre-commit git hooks to identify and resolve common issues.
+ - `r github("insightsengineering/r.pkg.template")` initializes a GitHub repository for an R package, with the standard files and directories, along with CI/CD configurations and pre-commit git hooks to identify and resolve common issues.
  - `r pkg("fusen")` and `r github("jacobbien/litr-project")` create a package from a R markdown file. `r pkg("noweb")` creates a package via literate programming with noweb syntax (as used by Sweave).
  - `r pkg("DataPackageR")` creates a package from a dataset. `r pkg("rcompendium")` creates the structure for a Research Compendium: an R package structure to support repreoducible research including raw data, analysis scripts, outputs and a make script.
  - `r pkg("leprechaun")` adds templating code to a package skeleton for creating a Shiny app as a package, without adding to the dependencies. `r pkg("golem")` creates a package template for developing and deploying a Shiny app using the `r pkg("golem")` framework.


### PR DESCRIPTION
Dropped a couple of items:

- [rfold](https://cran.r-project.org/web/packages/rfold/index.html) - although it is a CRAN package it uses an unconventional package structure (R code split into multiple folders), which I'm not sure we want to encourage.
- [cookiecutter](https://cran.r-project.org/web/packages/rfold/index.html) - focuses on projects rather than packages, so would probably require more work that it saves to use for a package.

Considered but not added:
- [skeletor](https://cran.rstudio.com/web/packages/skeletor/index.html) - looks a bit dated, e.g. adds Travis and Appveyor YAML for CI on GitHub.
- [mvbutils](https://cran.rstudio.com/web/packages/mvbutils/index.html) - bundles some package creation/management tools with various other utils, including masking `base::rbind.data.frame()` to change its behaviour. Package creation tied to package's approach to managing projects in hierarchical directories. Package maintenance tools seem dated, e.g. recommends to precompile PDF vignettes.
- [swagger](https://cran.r-project.org/web/packages/swagger/index.html) - is for creating package APIs and covered in Web Technologies task view.
- [rhino](https://appsilon.github.io/rhino/index.html) - creates a Shiny app, not an R package
- [metamakr](https://github.com/jdtrat/metamakr/) - similar to pkgverse, but only 5 commits, not on CRAN and no tests or checks.