### PR TITLE
add items for help pages

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -111,7 +111,7 @@ SEE ALSO (map to relevant subsections):
 #### Help pages
 
 Source files for help pages use the "R documentation" (Rd) format. 
-`utils::prompt` and `utils::promptData` may be used to create an Rd template for a function or data set, respectively. `tools::checkRd` may be used to validate Rd files, e.g., detecting syntax errors.
+`utils::prompt()` and `utils::promptData()` may be used to create an Rd template for a function or data set, respectively. `tools::checkRd()` may be used to validate Rd files, e.g., detecting syntax errors.
 
 WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Writing-R-documentation-files)
 
@@ -119,7 +119,7 @@ WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/ma
 - `r pkg("sinew")` generates roxygen skeletons and updates the NAMESPACE and DESCRIPTION file as required; can be used to update as well as create royxgen documentation.  
 - `r pkg("roclang")` facilitates extracting components of documentation from an Rd file (in the same or another package) for reuse, by insertion in a roxygen comment.
 - `r pkg("pasteAsComment")` provides an RStudio addin to paste clipboard content as a roxygen block - useful for inserting examples; `r github("csgillespie/roxygen2Comment")` provides an RStudio addin to convert regular code to roxygen commented code and vice versa.
-- `r pkg("roxyglobals")` adds additional roxygen tags to generate R code defining global variables with `utils::globalVariables`. This can be used to avoid false positives in the package check when functions in the package call functions that use non-standard evaluation.
+- `r pkg("roxyglobals")` adds additional roxygen tags to generate R code defining global variables with `utils::globalVariables()`. This can be used to avoid false positives in the package check when functions in the package call functions that use non-standard evaluation.
 - `r pkg("Rdpack")` provides functions and Rd macros for developing documentation, e.g. adding template documentation for new arguments; importing references from BibTeX files, and evaluating R code then inserting the resulting output or graphic.
 - `r github("Genentech/rd2markdown")` converts Rd files to plain Markdown files; `r github("coolbutuseless/rd2list")` converts Rd files to an R list.
 

--- a/proposal.md
+++ b/proposal.md
@@ -55,11 +55,8 @@ pages (all the CRAN packages except those for Windows only and some from
 Bioconductor), vignettes or task views, using the search engine at
 <http://search.r-project.org/>.
 
-CONSIDER: Metacran: <https://www.r-pkg.org/>,
-<https://rdrr.io/>. 
-
-SEE ALSO:  
-<https://github.com/ropensci-archive/PackageDevelopment/blob/master/README-NOT.md#searching-for-existing-packages>
+- rOpenSci maintain a [Help Wanted](https://ropensci.org/help-wanted/) page that can be used to search for rOpenSci packages looking for (co-)maintainers. The [Wishlist](https://discuss.ropensci.org/c/wishlist/6) channel of the rOpenSci forum is used to discuss ideas for new packages/features.
+- [cran GitHub mirror](https://github.com/cran), an unofficial read-only mirror of all CRAN packages (including archived packages), enables search across the full package source files using [GitHub Code Search syntax](https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax).
 
 ### Intializing a package
 

--- a/proposal.md
+++ b/proposal.md
@@ -111,9 +111,17 @@ SEE ALSO (map to relevant subsections):
 #### Help pages
 
 Source files for help pages use the "R documentation" (Rd) format. 
-`utils::prompt` and `utils::promptData` may be used to create an Rd template for a function or data set, respectively. `tools::Rdcheck` may be used to validate Rd files, e.g., detecting syntax errors.
+`utils::prompt` and `utils::promptData` may be used to create an Rd template for a function or data set, respectively. `tools::checkRd` may be used to validate Rd files, e.g., detecting syntax errors.
 
 WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Writing-R-documentation-files)
+
+- `r pkg("roxygen2", priority = "core")` provides the `roxygenise()` function to generate Rd files from roxygen blocks: comments with specific markup in R source files. When used with Markdown, roxygen can greatly reduce the markup required in the documentation source. Several [development workflow](#development-workflow) packages support creating documentation with roxygen. `r pkg("Rdroxygen")` provides functions to convert Rd files to roxygen blocks; `r pkg("roxygen2md")` replaces Rd syntax in roxygen comments with the Markdown equivalent.
+- `r pkg("sinew")` generates roxygen skeletons and updates the NAMESPACE and DESCRIPTION file as required; can be used to update as well as create royxgen documentation.  
+- `r pkg("roclang")` facilitates extracting components of documentation from an Rd file (in the same or another package) for reuse, by insertion in a roxygen comment.
+- `r pkg("pasteAsComment")` provides an RStudio addin to paste clipboard content as a roxygen block - useful for inserting examples; `r github("csgillespie/roxygen2Comment")` provides an RStudio addin to convert regular code to roxygen commented code and vice versa.
+- `r pkg("roxyglobals")` adds additional roxygen tags to generate R code defining global variables with `utils::globalVariables`. This can be used to avoid false positives in the package check when functions in the package call functions that use non-standard evaluation.
+- `r pkg("Rdpack")` provides functions and Rd macros for developing documentation, e.g. adding template documentation for new arguments; importing references from BibTeX files, and evaluating R code then inserting the resulting output or graphic.
+- `r github("Genentech/rd2markdown")` converts Rd files to plain Markdown files; `r github("coolbutuseless/rd2list")` converts Rd files to an R list.
 
 #### Vignettes
 

--- a/proposal.md
+++ b/proposal.md
@@ -124,7 +124,8 @@ WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/ma
 - `r pkg("roxyglobals")` adds additional roxygen tags to generate R code defining global variables with `utils::globalVariables()`. This can be used to avoid false positives in the package check when functions in the package call functions that use non-standard evaluation.
 - `r github("moodymudskipper/devtag")` provides the `@dev` tag for creating developer documentation for unexported functions; `r github("ropensci-review-tools/srr")` adds tags to document adherence to rOpenSci's standards for software review.
 - `r pkg("Rdpack")` provides functions and Rd macros for developing documentation, e.g. adding template documentation for new arguments; importing references from BibTeX files, and evaluating R code then inserting the resulting output or graphic.
-- `r github("Genentech/rd2markdown")` converts Rd files to plain Markdown files; `r github("coolbutuseless/rd2list")` converts Rd files to an R list.
+- `r pkg("Rd2md")` converts Rd files to Markdown and creates a combined Markdown reference manual; `r github("Genentech/rd2markdown")` generates Markdown from a source Rd file or the help page of an installed package.
+- `r github("coolbutuseless/rd2list")` converts Rd files to an R list.
 
 #### Vignettes
 

--- a/proposal.md
+++ b/proposal.md
@@ -122,6 +122,7 @@ WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/ma
 - `r pkg("roclang")` facilitates extracting components of documentation from an Rd file (in the same or another package) for reuse, by insertion in a roxygen comment.
 - `r pkg("pasteAsComment")` provides an RStudio addin to paste clipboard content as a roxygen block - useful for inserting examples; `r github("csgillespie/roxygen2Comment")` provides an RStudio addin to convert regular code to roxygen commented code and vice versa.
 - `r pkg("roxyglobals")` adds additional roxygen tags to generate R code defining global variables with `utils::globalVariables()`. This can be used to avoid false positives in the package check when functions in the package call functions that use non-standard evaluation.
+- `r github("moodymudskipper/devtag")` provides the `@dev` tag for creating developer documentation for unexported functions; `r github("ropensci-review-tools/srr")` adds tags to document adherence to rOpenSci's standards for software review.
 - `r pkg("Rdpack")` provides functions and Rd macros for developing documentation, e.g. adding template documentation for new arguments; importing references from BibTeX files, and evaluating R code then inserting the resulting output or graphic.
 - `r github("Genentech/rd2markdown")` converts Rd files to plain Markdown files; `r github("coolbutuseless/rd2list")` converts Rd files to an R list.
 

--- a/proposal.md
+++ b/proposal.md
@@ -115,10 +115,10 @@ Source files for help pages use the "R documentation" (Rd) format.
 
 WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Writing-R-documentation-files)
 
-- `r pkg("roxygen2", priority = "core")` provides the `roxygenise()` function to generate Rd files from comments with specific markup in R source files. When used with Markdown, roxygen2 can greatly reduce the markup required in the documentation source. Several [development workflow](#development-workflow) packages support creating documentation with roxygen2. 
-     `r pkg("Rd2roxygen")` provides functions to convert Rd files to roxygen2 comments.
-     `r pkg("roxygen2md")` replaces Rd syntax in roxygen2 comments with the Markdown equivalent.
+- `r pkg("roxygen2", priority = "core")` provides the `roxygenise()` function to generate Rd files from comments with specific markup in R source files. When used with Markdown, `r pkg("roxygen2")` can greatly reduce the markup required in the documentation source. Several [development workflow](#development-workflow) packages support creating documentation with `r pkg("roxygen2")`. 
 - `r pkg("sinew")` generates roxygen skeletons and updates the NAMESPACE and DESCRIPTION file as required; can be used to update as well as create royxgen documentation.  
+- `r pkg("Rd2roxygen")` provides functions to convert Rd files to `r pkg("roxygen2")` comments.
+- `r pkg("roxygen2md")` replaces Rd syntax in `r pkg("roxygen2")` comments with the Markdown equivalent.
 - `r pkg("roclang")` facilitates extracting components of documentation from an Rd file (in the same or another package) for reuse, by insertion in a roxygen comment.
 - `r pkg("pasteAsComment")` provides an RStudio addin to paste clipboard content as a roxygen block - useful for inserting examples; `r github("csgillespie/roxygen2Comment")` provides an RStudio addin to convert regular code to roxygen commented code and vice versa.
 - `r pkg("roxyglobals")` adds additional roxygen tags to generate R code defining global variables with `utils::globalVariables()`. This can be used to avoid false positives in the package check when functions in the package call functions that use non-standard evaluation.

--- a/proposal.md
+++ b/proposal.md
@@ -115,7 +115,9 @@ Source files for help pages use the "R documentation" (Rd) format.
 
 WRE reference: [Writing R documentation files](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Writing-R-documentation-files)
 
-- `r pkg("roxygen2", priority = "core")` provides the `roxygenise()` function to generate Rd files from roxygen blocks: comments with specific markup in R source files. When used with Markdown, roxygen can greatly reduce the markup required in the documentation source. Several [development workflow](#development-workflow) packages support creating documentation with roxygen. `r pkg("Rdroxygen")` provides functions to convert Rd files to roxygen blocks; `r pkg("roxygen2md")` replaces Rd syntax in roxygen comments with the Markdown equivalent.
+- `r pkg("roxygen2", priority = "core")` provides the `roxygenise()` function to generate Rd files from comments with specific markup in R source files. When used with Markdown, roxygen2 can greatly reduce the markup required in the documentation source. Several [development workflow](#development-workflow) packages support creating documentation with roxygen2. 
+     `r pkg("Rd2roxygen")` provides functions to convert Rd files to roxygen2 comments.
+     `r pkg("roxygen2md")` replaces Rd syntax in roxygen2 comments with the Markdown equivalent.
 - `r pkg("sinew")` generates roxygen skeletons and updates the NAMESPACE and DESCRIPTION file as required; can be used to update as well as create royxgen documentation.  
 - `r pkg("roclang")` facilitates extracting components of documentation from an Rd file (in the same or another package) for reuse, by insertion in a roxygen comment.
 - `r pkg("pasteAsComment")` provides an RStudio addin to paste clipboard content as a roxygen block - useful for inserting examples; `r github("csgillespie/roxygen2Comment")` provides an RStudio addin to convert regular code to roxygen commented code and vice versa.


### PR DESCRIPTION
Considered but not included:

* [inlinedocs](https://cran.r-project.org/package=inlinedocs) - seems only to be used by one of author's own packages, superseded/out-competed by roxygen2.
* [gbRd](https://cran.r-project.org/package=gbRd) - mainly a workhorse package for Rdpack, already mentioned.
* [katex](https://cran.r-project.org/package=katex) - has math_md() function for embedding math in R documentation; can't see this is any different from what R does since R 4.2.0. Similarly [mathjaxr](https://github.com/wviechtb/mathjaxr) may now be superseded by improved KaTeX/MathJax handling in Rd files. **katex** may be worth mentioning in the vignette section for creating HTML vignettes where math continues to display offline (need to test).

