### PR TITLE
Add packages and text

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -158,8 +158,8 @@ reported but not causing an error.
 WRE reference: [Package subdirectories](https://cran.r-project.org/doc/manuals/R-exts.html#Package-subdirectories)
 
 These packages provide some automation and helpers to test code:
- - `r pkg("tinytest")` allows to add tests to a package with no further dependencies and includes the tests in the installed package, making them available to users.
- - `r pkg("testthat")` helpers for tests including snapshot tests. `r pkg("patrick")` allows to parameterize testing with testthat. `r pkg("hySpc.testthat")` attaches the tests to functions.
+ - `r pkg("tinytest", priority = "core")` allows to add tests to a package with no further dependencies and includes the tests in the installed package, making them available to users.
+ - `r pkg("testthat", priority = "core")` helpers for tests including snapshot tests. `r pkg("patrick")` allows to parameterize testing with testthat. `r pkg("hySpc.testthat")` attaches the tests to functions.
  - `r pkg("RUnit")` and `r pkg("svUnit")` provides alternative unit testing frameworks, similar to `r pkg("testthat")`
  - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()` for a simple unit testing interface with minimal dependencies.
  - `r pkg("roxytest")` and `r pkg("roxut")` provide `r pkg("roxygen2")` roclets for testing with testthat and tinytest.

--- a/proposal.md
+++ b/proposal.md
@@ -161,7 +161,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("tinytest")` allows to add tests to a package with no further dependencies and includes the tests in the installed package, making them available to users.
  - `r pkg("testthat")` helpers for tests including snapshot tests. `r pkg("patrick")` allows to parameterize testing with testthat. `r pkg("hySpc.testthat")` attaches the tests to functions.
  - `r pkg("RUnit")` and `r pkg("svUnit")` provides alternative unit testing frameworks, similar to `r pkg("testthat")`
- - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()`.
+ - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()` for a simple unit testing interface with minimal dependencies.
  - `r pkg("roxytest")` and `r pkg("roxut")` provide `r pkg("roxygen2")` roclets for testing with testthat and tinytest.
  - `r pkg("realtest")` testing with distinct behaviours: expected, acceptable, current, fallback, ideal, or regressive.
  - `r pkg("unitizer")` provides testing helper that allows interactive unit tests.

--- a/proposal.md
+++ b/proposal.md
@@ -209,9 +209,8 @@ One can use [this book "HTTP testing in R"](https://books.ropensci.org/http-test
 Other packages focused on specific areas:
  - `r pkg("gdiff")` and `r pkg("vdiffr")` provide helpers for visual tests on graphical output. vdiffr integrates with testthat and provides a Shiny app to manage test cases.
  - `r pkg("shinytest2")` provides a testing framework for Shiny applications.
- - `r pkg("validate")` declares data validation rules and data quality indicators.
  - `r pkg("mcunit")` helps with unit testing MCMC methods.
- - `r pkg("checkmate")` and `r pkg("testdate")` package which extend testthat for data structures unit testing.
+ - `r pkg("checkmate")` and `r pkg("testdat")` package which extend testthat for data structures unit testing.
 
 #### Code coverage
 

--- a/proposal.md
+++ b/proposal.md
@@ -158,7 +158,7 @@ reported but not causing an error.
 WRE reference: [Package subdirectories](https://cran.r-project.org/doc/manuals/R-exts.html#Package-subdirectories)
 
 These packages provide some automation and helpers to test code:
- - `r pkg("tinytest")` allows to install tests with the package with no further dependencies.
+ - `r pkg("tinytest")` allows to add tests to a package with no further dependencies and includes the tests in the installed package, making them available to users.
  - `r pkg("testthat")` helpers for tests including snapshot tests. `r pkg("patrick")` allows to parameterize testing with testthat. `r pkg("hySpc.testthat")` attaches the tests to functions.
  - `r pkg("RUnit")` provides test for the Unit Testing framework.
  - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()`.

--- a/proposal.md
+++ b/proposal.md
@@ -174,7 +174,7 @@ These packages provide some automation and helpers to test code:
 
 Testing internet requests can be difficult to do it reliably. 
 One can use [this book "HTTP testing in R"](https://books.ropensci.org/http-testing/) to take inspiration:
- - `r pkg("vcr")` records requests and replays them during future runs. 
+ - `r pkg("vcr")` records HTTP requests and replays them during future runs. 
  - `r pkg("webmockr")` stubbing and setting expectations on 'HTTP' requests. 
  - `r pkg("httptest2")` works for recording and saving requests made by the httr2 package without requiring access to the remote service.
 

--- a/proposal.md
+++ b/proposal.md
@@ -160,7 +160,7 @@ WRE reference: [Package subdirectories](https://cran.r-project.org/doc/manuals/R
 These packages provide some automation and helpers to test code:
  - `r pkg("tinytest")` allows to add tests to a package with no further dependencies and includes the tests in the installed package, making them available to users.
  - `r pkg("testthat")` helpers for tests including snapshot tests. `r pkg("patrick")` allows to parameterize testing with testthat. `r pkg("hySpc.testthat")` attaches the tests to functions.
- - `r pkg("RUnit")` provides test for the Unit Testing framework.
+ - `r pkg("RUnit")` and `r pkg("svUnit")` provides alternative unit testing frameworks, similar to `r pkg("testthat")`
  - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()`.
  - `r pkg("roxytest")` and `r pkg("roxut")` provide `r pkg("roxygen2")` roclets for testing with testthat and tinytest.
  - `r pkg("realtest")` testing with distinct behaviours: expected, acceptable, current, fallback, ideal, or regressive.

--- a/proposal.md
+++ b/proposal.md
@@ -168,7 +168,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("unittest")` testing using the Test Anything Protocol, producing test output in a standard text format.
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into tests to be run by testthat.
  - `r pkg("cucumber")` integrates with testthat to run tests specified using the 'Gherkin' language to describe high level scenarios, e.g. when <I do this>, then <this should happen>.
- - `r pkg("quickcheck")` checks against randomly generated inputs and is compatible with testthat.
+ - `r pkg("quickcheck")` and `r pkg("autotest")` check against randomly generated inputs and are compatible with testthat. 
  - `r pkg("xpectr")` provides tools for generating expectations for testthat tests in a systematic way.
  
 
@@ -177,11 +177,14 @@ One can use [this book "HTTP testing in R"](https://books.ropensci.org/http-test
  - `r pkg("vcr")` records HTTP requests and replays them during future runs. 
  - `r pkg("webmockr")` stubbing (generating dummy results) and setting expectations on 'HTTP' requests. 
  - `r pkg("httptest2")` works for recording and saving requests made by the httr2 package without requiring access to the remote service.
+ - `r pkg("webfakes")` allows to create and launch fake apps in test files, for testing complex behaviour.
 
 Other packages focused on specific areas:
  - `r pkg("gdiff")` and `r pkg("vdiffr")` provide helpers for visual tests on graphical output. vdiffr integrates with testthat and provides a Shiny app to manage test cases.
  - `r pkg("shinytest2")` provides a testing framework for Shiny applications.
  - `r pkg("validate")` declares data validation rules and data quality indicators.
+ - `r pkg("mcunit")` helps with unit testing MCMC methods.
+ - `r pkg("checkmate")` and `r pkg("testdate")` package which extend testthat for data structures unit testing.
 
 #### Code coverage
 

--- a/proposal.md
+++ b/proposal.md
@@ -165,7 +165,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("roxytest")` and `r pkg("roxut")` provide `r pkg("roxygen2")` roclets for testing with testthat and tinytest.
  - `r pkg("realtest")` testing with distinct behaviours: expected, acceptable, current, fallback, ideal, or regressive.
  - `r pkg("unitizer")` provides a testing framework for interactive regression testing, making it simpler to review and debug tests.
- - `r pkg("unittest")` testing using the Test Anything Protocol.
+ - `r pkg("unittest")` testing using the Test Anything Protocol, producing test output in a standard text format.
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into test to be run by testthat.
  - `r pkg("cucumber")` write specifications in feature files using 'Gherkin' language.
  - `r pkg("quickcheck")` checks against randomly generated input and compatible with testthat.

--- a/proposal.md
+++ b/proposal.md
@@ -195,7 +195,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("unittest")` testing using the Test Anything Protocol, producing test output in a standard text format.
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into tests to be run by testthat.
  - `r pkg("cucumber")` integrates with testthat to run tests specified using the 'Gherkin' language to describe high level scenarios, e.g. when <I do this>, then <this should happen>.
- - `r pkg("quickcheck")` and `r pkg("autotest")` check against randomly generated inputs and are compatible with testthat. 
+ - `r pkg("quickcheck")` and `r github("ropensci-review-tools/autotest")` check against randomly generated inputs and are compatible with testthat. 
  - `r pkg("xpectr")` provides tools for generating expectations for testthat tests in a systematic way.
  
 

--- a/proposal.md
+++ b/proposal.md
@@ -175,7 +175,7 @@ These packages provide some automation and helpers to test code:
 Testing internet requests can be difficult to do it reliably. 
 One can use [this book "HTTP testing in R"](https://books.ropensci.org/http-testing/) to take inspiration:
  - `r pkg("vcr")` records HTTP requests and replays them during future runs. 
- - `r pkg("webmockr")` stubbing and setting expectations on 'HTTP' requests. 
+ - `r pkg("webmockr")` stubbing (generating dummy results) and setting expectations on 'HTTP' requests. 
  - `r pkg("httptest2")` works for recording and saving requests made by the httr2 package without requiring access to the remote service.
 
 Other packages focused on specific areas:

--- a/proposal.md
+++ b/proposal.md
@@ -179,7 +179,7 @@ One can use [this book "HTTP testing in R"](https://books.ropensci.org/http-test
  - `r pkg("httptest2")` works for recording and saving requests made by the httr2 package without requiring access to the remote service.
 
 Other packages focused on specific areas:
- - `r pkg("vdiffr")` provides helpers for graphical unit tests, testing visual differences.
+ - `r pkg("gdiff")` and `r pkg("vdiffr")` provide helpers for visual tests on graphical output. vdiffr integrates with testthat and provides a Shiny app to manage test cases.
  - `r pkg("shinytest2")` provides a testing framework for Shiny applications.
  - `r pkg("validate")` declares data validation rules and data quality indicators.
 

--- a/proposal.md
+++ b/proposal.md
@@ -157,9 +157,31 @@ reported but not causing an error.
 
 WRE reference: [Package subdirectories](https://cran.r-project.org/doc/manuals/R-exts.html#Package-subdirectories)
 
-CONSIDER: valtools, vdiffr, httptest2, tinytest, vcr, dgkf/testex
+These packages provide some automation and helpers to test code:
+ - `r pkg("tinytest")` allows to install tests with the package with no further dependencies.
+ - `r pkg("testthat")` helpers for tests including snapshot tests. `r pkg("patrick")` allows to parameterize testing with testthat. `r pkg("hySpc.testthat")` attaches the tests to functions.
+ - `r pkg("RUnit")` provides test for the Unit Testing framework.
+ - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()`.
+ - `r pkg("roxytest")` and `r pkg("roxut")` provide `r pkg("roxygen2")` roclets for testing with testthat and tinytest.
+ - `r pkg("realtest")` testing with distinct behaviours: expected, acceptable, current, fallback, ideal, or regressive.
+ - `r pkg("unitizer")` provides testing helper that allows interactive unit tests.
+ - `r pkg("unittest")` testing using the Test Anything Protocol.
+ - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into test to be run by testthat.
+ - `r pkg("cucumber")` write specifications in feature files using 'Gherkin' language.
+ - `r pkg("quickcheck")` checks against randomly generated input and compatible with testthat.
+ - `r pkg("xpectr")` provides tools for generating expectations in a systematic way.
+ 
 
-SEE ALSO:   https://github.com/ropensci-archive/PackageDevelopment/blob/master/README-NOT.md#unit-testing, https://github.com/IndrajeetPatil/awesome-r-pkgtools?tab=readme-ov-file#unit-testing-
+Testing internet requests can be difficult to do it reliably. 
+One can use [this book "HTTP testing in R"](https://books.ropensci.org/http-testing/) to take inspiration:
+ - `r pkg("vcr")` records requests and replays them during future runs. 
+ - `r pkg("webmockr")` stubbing and setting expectations on 'HTTP' requests. 
+ - `r pkg("httptest2")` works for recording and saving requests made by the httr2 package without requiring access to the remote service.
+
+Other packages focused on specific areas:
+ - `r pkg("vdiffr")` provides helpers for graphical unit tests, testing visual differences.
+ - `r pkg("shinytest2")` provides a testing framework for Shiny applications.
+ - `r pkg("validate")` declares data validation rules and data quality indicators.
 
 #### Code coverage
 

--- a/proposal.md
+++ b/proposal.md
@@ -169,7 +169,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into tests to be run by testthat.
  - `r pkg("cucumber")` integrates with testthat to run tests specified using the 'Gherkin' language to describe high level scenarios, e.g. when <I do this>, then <this should happen>.
  - `r pkg("quickcheck")` checks against randomly generated input and compatible with testthat.
- - `r pkg("xpectr")` provides tools for generating expectations in a systematic way.
+ - `r pkg("xpectr")` provides tools for generating expectations for testthat tests in a systematic way.
  
 
 Testing internet requests can be difficult to do it reliably. 

--- a/proposal.md
+++ b/proposal.md
@@ -164,7 +164,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("testit")` provides two convenience functions `assert()` and `test_pkg()` for a simple unit testing interface with minimal dependencies.
  - `r pkg("roxytest")` and `r pkg("roxut")` provide `r pkg("roxygen2")` roclets for testing with testthat and tinytest.
  - `r pkg("realtest")` testing with distinct behaviours: expected, acceptable, current, fallback, ideal, or regressive.
- - `r pkg("unitizer")` provides testing helper that allows interactive unit tests.
+ - `r pkg("unitizer")` provides a testing framework for interactive regression testing, making it simpler to review and debug tests.
  - `r pkg("unittest")` testing using the Test Anything Protocol.
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into test to be run by testthat.
  - `r pkg("cucumber")` write specifications in feature files using 'Gherkin' language.

--- a/proposal.md
+++ b/proposal.md
@@ -167,7 +167,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("unitizer")` provides a testing framework for interactive regression testing, making it simpler to review and debug tests.
  - `r pkg("unittest")` testing using the Test Anything Protocol, producing test output in a standard text format.
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into tests to be run by testthat.
- - `r pkg("cucumber")` write specifications in feature files using 'Gherkin' language.
+ - `r pkg("cucumber")` integrates with testthat to run tests specified using the 'Gherkin' language to describe high level scenarios, e.g. when <I do this>, then <this should happen>.
  - `r pkg("quickcheck")` checks against randomly generated input and compatible with testthat.
  - `r pkg("xpectr")` provides tools for generating expectations in a systematic way.
  

--- a/proposal.md
+++ b/proposal.md
@@ -168,7 +168,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("unittest")` testing using the Test Anything Protocol, producing test output in a standard text format.
  - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into tests to be run by testthat.
  - `r pkg("cucumber")` integrates with testthat to run tests specified using the 'Gherkin' language to describe high level scenarios, e.g. when <I do this>, then <this should happen>.
- - `r pkg("quickcheck")` checks against randomly generated input and compatible with testthat.
+ - `r pkg("quickcheck")` checks against randomly generated inputs and is compatible with testthat.
  - `r pkg("xpectr")` provides tools for generating expectations for testthat tests in a systematic way.
  
 

--- a/proposal.md
+++ b/proposal.md
@@ -166,7 +166,7 @@ These packages provide some automation and helpers to test code:
  - `r pkg("realtest")` testing with distinct behaviours: expected, acceptable, current, fallback, ideal, or regressive.
  - `r pkg("unitizer")` provides a testing framework for interactive regression testing, making it simpler to review and debug tests.
  - `r pkg("unittest")` testing using the Test Anything Protocol, producing test output in a standard text format.
- - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into test to be run by testthat.
+ - `r pkg("exampletestr")` and `r pkg("doctest")` convert examples into tests to be run by testthat. `r pkg("testex")` converts documentation by roxygen2 into tests to be run by testthat.
  - `r pkg("cucumber")` write specifications in feature files using 'Gherkin' language.
  - `r pkg("quickcheck")` checks against randomly generated input and compatible with testthat.
  - `r pkg("xpectr")` provides tools for generating expectations in a systematic way.


### PR DESCRIPTION
Packages considered but in the end not added:
hedgehog is the workhorse of quickcheck, I mention the later.
valtools considered but it is not for testing but validation. 
testthis but this is only for addins for Rstudio not really for testing

I was considering also ropensci-review-tools/autotest but it is a general tool not specific and seems also specific to rOpenSci.

Closes #3 