### PR TITLE
add items for code coverage

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -171,7 +171,8 @@ SEE ALSO:   https://github.com/ropensci-archive/PackageDevelopment/blob/master/R
 
 #### Code coverage
 
-SEE ALSO:   https://github.com/IndrajeetPatil/awesome-r-pkgtools?tab=readme-ov-file#code-coverage
+- `r pkg(covr, priority = "core")` track and reports code coverage of package tests and optionally uploads the results to a service like [Codecov](https://about.codecov.io) or [Coveralls](https://coveralls.io).
+- `r pkg(covtracer)` links tested code to documentation, to evaluate coverage of documented behaviours.
 
 ### Working with package options
 


### PR DESCRIPTION
Another short section. Did not include:

* covrpage - github package does not seem to be actively maintained, main functionality (public coverage report) provided by Codecov/Coveralls via covr.