### PR TITLE
28 add items for localisation

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -229,7 +229,7 @@ Localization in R uses GNU `gettext` as described in the notes on [Translating R
 and updates corresponding PO (`.po`) files as required. `tools::checkPoFile()` can be 
 used to check translation files for inconsistently formatted strings.
 
-* `r pkg(potools)` provides helpers to create/update `.pot` and `.po` files, compile the `.po` files for distribution in a package, and run diagnostics to detect issues, e.g., untranslated messages due to inappropriate R/C code.
+* `r pkg(potools, priority = "core")` provides helpers to create/update `.pot` and `.po` files, compile the `.po` files for distribution in a package, and run diagnostics to detect issues, e.g., untranslated messages due to inappropriate R/C code.
 * Alternative mechanisms for localization of R messages are provided by `r pkg(stranslate)` 
 and `r pkg(translated)`, using plain text and JSON files respectively. 
 * `r github("eliocamp/rhelpi18n")` provides experimental support for localization of help pages, based on YAML files provided by companion packages.

--- a/proposal.md
+++ b/proposal.md
@@ -223,13 +223,16 @@ For simple interactive interfaces, `base::readline()` can be used to create a ba
 ### Localisation
 
 Packages might be addressed to people using a different language and locale. 
-Localization in R uses GNU `gettext` as described in the notes on [Translating R Messages](https://developer.r-project.org/Translations30.html) which uses translations stored in PO files.
+Localization in R uses GNU `gettext` as described in the notes on [Translating R Messages](https://developer.r-project.org/Translations30.html) which uses translations stored in PO files. 
+This approach has the advantage of being supported by general translation software such as [Poedit](https://poedit.net/).
 
-`tools:update_pkg_po` creates or updates the PO template files for a package, 
-and updates corresponding PO files as required. `tools::checkPoFile` can be 
-used to check translation files for inconsistent format strings.
+`tools::update_pkg_po()` creates or updates the PO template (`.pot`) files for a package, 
+and updates corresponding PO (`.po`) files as required. `tools::checkPoFile()` can be 
+used to check translation files for inconsistently formatted strings.
 
-CONSIDER: potools, https://github.com/eliocamp/rhelpi18n
+* `r pkg(potools)` provides helpers to create/update `.pot` and `.po` files, compile the `.po` files for distribution in a package, and run diagnostics to detect issues, e.g., untranslated messages due to inappropriate R/C code.
+* Alternative mechanisms for localisation are provided by `r pkg(stranslate)` 
+and `r pkg(translated)`, using plain text and JSON files respectively. 
 
 ### Building and installing a source package
 

--- a/proposal.md
+++ b/proposal.md
@@ -220,19 +220,19 @@ For simple interactive interfaces, `base::readline()` can be used to create a ba
   * `r pkg(progress)` provides configurable text progress bars, for R and C++.
   * `r pkg(shiny)` provides a framework to create browser-based interfaces, from function dialogues to more complex interactive web applications, that can be run locally with `runApp()` or deployed as static web or dynamic websites. See the [Web Technologies and Services](https://cran.r-project.org/web/views/WebTechnologies.html#frameworks) task view for other frameworks for building R-based web applications.
 
-### Localisation
+### Localization
 
 Packages might be addressed to people using a different language and locale. 
 Localization in R uses GNU `gettext` as described in the notes on [Translating R Messages](https://developer.r-project.org/Translations30.html) which uses translations stored in PO files. 
-This approach has the advantage of being supported by general translation software such as [Poedit](https://poedit.net/).
 
 `tools::update_pkg_po()` creates or updates the PO template (`.pot`) files for a package, 
 and updates corresponding PO (`.po`) files as required. `tools::checkPoFile()` can be 
 used to check translation files for inconsistently formatted strings.
 
 * `r pkg(potools)` provides helpers to create/update `.pot` and `.po` files, compile the `.po` files for distribution in a package, and run diagnostics to detect issues, e.g., untranslated messages due to inappropriate R/C code.
-* Alternative mechanisms for localisation are provided by `r pkg(stranslate)` 
+* Alternative mechanisms for localization of R messages are provided by `r pkg(stranslate)` 
 and `r pkg(translated)`, using plain text and JSON files respectively. 
+* `r github("eliocamp/rhelpi18n")` provides experimental support for localization of help pages, based on YAML files provided by companion packages.
 
 ### Building and installing a source package
 


### PR DESCRIPTION
I thought eliocamp/rhelpi18n was important enough to mention even though it's experimental - package authors may wish to experiment with it, e.g. creating translation modules for CRAN packages that are hosted on GitHub.

I originally though packages like stranslate and translated might not be compatible with standard translation software, but it seems plain text and JSON formats (among others) are also supported by tools like OmegaT (possibly with Okapi filters), GitLocalize, Weblate and Crowdin, so package authors may prefer these alternatives to the standard PO/POT files.

(the same tools can also handle YAML format as used by rhelpi18n).