### PR TITLE
add packages for building and installing source packages

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -266,7 +266,7 @@ The standard tools to build and install a package are `R CMD build` and
 
 - `r pkg("pkgbuild")` provides the `build()` function to build R packages and has several utilities to facilitate building packages with compiled code.
 - `r pkg("pkgload")` simulates the process of installing a package and then attaching it, enabling rapid iterative development.
-- There are many packages to facilitate installing packages from remote source code repositories, such as GitHub. `r pkg("remotes")` has no dependencies and will install packages with their dependencies from any git or subversion repository. `r pkg{"ipkg"}` depends on remotes and facilitates using a proxy website if you don't have access to GitHub.
+- There are many packages to facilitate installing packages from remote source code repositories, including those hosted on platforms like GitHub or GitLab. `r pkg("remotes")` has no dependencies and will install packages from any git or subversion repository accessible from a URL, with helpers for specific cases. In particular, `remotes::install_bioc()` can be used to install the development version of a Bioconductor package. `r pkg{"ipkg"}` depends on remotes and facilitates installing GitHub packages using a proxy website, if you don't have access to GitHub.
 
 ### Checking a package
 

--- a/proposal.md
+++ b/proposal.md
@@ -264,7 +264,9 @@ and `r pkg(translated)`, using plain text and JSON files respectively.
 The standard tools to build and install a package are `R CMD build` and 
 `R CMD INSTALL`.
 
-CONSIDER: pkgload, remotes::install_github(), R universe
+- `r pkg("pkgbuild")` provides the `build()` function to build R packages and has several utilities to facilitate building packages with compiled code.
+- `r pkg("pkgload")` simulates the process of installing a package and then attaching it, enabling rapid iterative development.
+- There are many packages to facilitate installing packages from remote source code repositories, such as GitHub. `r pkg("remotes")` has no dependencies and will install packages with their dependencies from any git or subversion repository. 
 
 ### Checking a package
 

--- a/proposal.md
+++ b/proposal.md
@@ -266,7 +266,7 @@ The standard tools to build and install a package are `R CMD build` and
 
 - `r pkg("pkgbuild")` provides the `build()` function to build R packages and has several utilities to facilitate building packages with compiled code.
 - `r pkg("pkgload")` simulates the process of installing a package and then attaching it, enabling rapid iterative development.
-- There are many packages to facilitate installing packages from remote source code repositories, such as GitHub. `r pkg("remotes")` has no dependencies and will install packages with their dependencies from any git or subversion repository. 
+- There are many packages to facilitate installing packages from remote source code repositories, such as GitHub. `r pkg("remotes")` has no dependencies and will install packages with their dependencies from any git or subversion repository. `r pkg{"ipkg"}` depends on remotes and facilitates using a proxy website if you don't have access to GitHub.
 
 ### Checking a package
 


### PR DESCRIPTION
I just added a few here in the end. As noted, there are many packages for installing packages from remote repositories:

- Some are CRAN only: install.load, needs
- Others also work with Bioconductor and/or GitHub: anylib, easypackages, githubinstall, just.install, librarian ,pacman,  pak
- Others are focused on reproducibility (some in Reproducible Research TV): checkpoint, dateback, guix.install, versions

In general these are focused on users more than developers, some depend on {remotes}, which is the only one I have specifically mentioned, as it has no dependencies (only base packages).

P.S. Added {ipkg} too as it helps people that can't access GitHub, trying multiple proxy websites if required.

